### PR TITLE
feat: Missing manuscripts.

### DIFF
--- a/demo/config.yaml
+++ b/demo/config.yaml
@@ -25,3 +25,6 @@ stemma:
     law: Uniform
     min: 2
     max: 4
+  missing_manuscripts:
+    law: Bernouilli
+    rate: 0.5

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -2,5 +2,10 @@
 
 StemmaBench generates two outputs within the `output_folder` specified in the command line:
 
-- A file `edge.txt` which represents the tree as a set of node.
-- A set of file `*.txt` which contain the copied text and which number represent their hierarchy in the tree. `0` is the first text, then `0_0` and `0_1` are its descendants, then `0_0_0` and `0_0_1` are the descendants of `0_0` in a bifid tree fashion, etc.
+1. A file `edge.txt` which represents the tree as a set of node.
+2. A set of file `*.txt` which contain the copied text and which number represent their hierarchy in the tree. `0` is the first text, then `0_0` and `0_1` are its descendants, then `0_0_0` and `0_0_1` are the descendants of `0_0` in a bifid tree fashion, etc.
+
+Furthermore, if the `rate` parameter of the `missing_manuscripts` option is greater than zero, an additional folder called `missing_tradition` is created within the `output_folder` specified in the command line. This folder includes:
+
+- A file named `edge_missing.txt` containing the edges connecting the non-missing manuscripts still available.
+- A collection of `*.txt` files with the remaining manuscripts in the tradition. These files exclude any manuscripts that were deleted during the process.

--- a/docs/variants.md
+++ b/docs/variants.md
@@ -32,6 +32,9 @@ stemma:
     law: Uniform
     min: 2
     max: 4
+  missing_manuscripts:
+    law: Bernouilli
+    rate: 0.5
 ```
 
 ## Scribal dependent variants
@@ -56,7 +59,11 @@ Possible variants are:
 ### Fragmentation
 
 ### Missing manuscripts
+In the StemmaBench package, the concept of missing manuscripts is modeled using a probabilistic process governed by a p-parameter Bernoulli distribution. After having generating the whole tradition, a proportion *p* of the manuscripts are selected (with equiprobability) and deleted from the tradition. This simulates the loss of certain manuscripts over time.
 
+> [!WARNING]
+> 
+> Currently, the missing manunscript feature is only available in command-line interface, not in RAM.
 
 ## Supported languages
 Two languages are currently supported:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
   "pydantic==1.9.1",
   "PyYAML==6.0",
   "typer==0.4.1",
-  "wheel"
+  "wheel",
+  "numpy==1.25.2"
 ]
 
 [project.scripts]

--- a/src/stemmabench/config_parser.py
+++ b/src/stemmabench/config_parser.py
@@ -61,6 +61,7 @@ class StemmaConfig(BaseModel):
     """
     depth: int
     width: ProbabilisticConfig
+    missing_manuscripts: ProbabilisticConfig
 
 
 class MetaConfig(BaseModel):

--- a/src/stemmabench/stemma_generator.py
+++ b/src/stemmabench/stemma_generator.py
@@ -166,7 +166,6 @@ class Stemma:
             level_name += f":{self.depth - remaining_depth - 1}"
             # Decrease remaining depth
             remaining_depth -= 1
-        # Missing manuscript.
         # Return self
         return self
 
@@ -176,8 +175,7 @@ class Stemma:
             - The corresponding tree structure
 
         Args:
-            folder (str): The folder where the text should be
-                written.
+            folder (str): The folder where the text should be written.
         """
         Path(folder).mkdir(exist_ok=True)
         for file_name, file_content in self.texts_lookup.items():

--- a/src/stemmabench/textual_units/sentence.py
+++ b/src/stemmabench/textual_units/sentence.py
@@ -1,9 +1,9 @@
 """This module define a class `Sentence` whose methods apply transformations 
 at the sentence level.
 """
-import random
 import re
 import string
+import numpy as np
 
 
 class Sentence:
@@ -46,7 +46,7 @@ class Sentence:
             str: The newly generated sentence.
         """
         if self.nbr_words > nbr_words + 1:
-            random_location = random.randrange(self.nbr_words - nbr_words)
+            random_location = np.random.randint(self.nbr_words - nbr_words)
             generated_sentence = " ".\
                 join(
                     self.words[:random_location]

--- a/src/stemmabench/textual_units/text.py
+++ b/src/stemmabench/textual_units/text.py
@@ -1,8 +1,9 @@
 """This module define a class `Text` whose methods apply transformations at 
 the text level.
 """
-import random
 from typing import Any, Dict
+
+import numpy as np
 from stemmabench.config_parser import ProbabilisticConfig, VariantConfig, MetaConfig
 from stemmabench.textual_units.sentence import Sentence
 from stemmabench.textual_units.word import Word
@@ -42,7 +43,7 @@ class Text:
         Returns:
             bool: The result of the draw
         """
-        return random.random() < rate
+        return np.random.random() < rate
 
     def transform_word(self,
                        word: Word,

--- a/src/stemmabench/textual_units/word.py
+++ b/src/stemmabench/textual_units/word.py
@@ -1,10 +1,10 @@
 """This module define the `Word` class whose methods apply transformations at 
 the word level.
 """
-import random
 import re
 import string
 
+import numpy as np
 from loguru import logger
 from stemmabench.data import SUPPORTED_LANGUAGES, SYNONYM_DICT, LETTERS
 
@@ -52,9 +52,8 @@ class Word:
         try:
             synonyms = self.synonyms[self.word]
             if len(synonyms):
-                return synonyms[random.randrange(len(synonyms))]
-            else:
-                logger.debug(f"Could not find synonym for word {self.word}")
+                return synonyms[np.random.randint(0, len(synonyms))]
+            logger.debug(f"Could not find synonym for word {self.word}")
         except KeyError:
             logger.debug(f"Could not find synonym for word {self.word}")
         return self.word
@@ -66,9 +65,9 @@ class Word:
             str: The mispelled word.
         """
         if self.word:
-            random_location = random.randrange(len(self.word))
+            random_location = np.random.randint(0, len(self.word))
             return self.word[:random_location] + \
-                random.choice(LETTERS[self.language]) + \
+                np.random.choice(list(LETTERS[self.language])) + \
                 self.word[random_location + 1:]
         return self.word
 

--- a/src/tests/test_data/config.yaml
+++ b/src/tests/test_data/config.yaml
@@ -28,4 +28,4 @@ stemma:
     max: 4
   missing_manuscripts:
     law: Bernouilli
-    rate: 0
+    rate: 0.5

--- a/src/tests/test_data/config.yaml
+++ b/src/tests/test_data/config.yaml
@@ -26,3 +26,6 @@ stemma:
     law: Uniform
     min: 2
     max: 4
+  missing_manuscripts:
+    law: Bernouilli
+    rate: 0

--- a/src/tests/test_generate_tree.py
+++ b/src/tests/test_generate_tree.py
@@ -1,7 +1,8 @@
 """Unit tests for the stemma generator.
 """
-
 import unittest
+import os
+import shutil
 from pathlib import Path
 
 import numpy as np
@@ -9,12 +10,11 @@ from stemmabench.config_parser import StemmaBenchConfig
 from stemmabench.stemma_generator import Stemma
 
 TEST_YAML = Path(__file__).resolve().parent / "test_data" / "config.yaml"
-
+OUTPUT_FOLDER = "output_folder"
 
 class TestStemmaGenerator(unittest.TestCase):
     """Unit tests for the stemma generator.
     """
-
     def setUp(self):
         """Set-up the data to test the generation.
         """
@@ -25,6 +25,16 @@ class TestStemmaGenerator(unittest.TestCase):
             original_text=self.text,
             config=config
         )
+        # Create the output folder
+        os.mkdir(OUTPUT_FOLDER)
+
+
+    def tearDown(self):
+        """Clean up by deleting the output folder and its contents.
+        """
+        if os.path.exists(OUTPUT_FOLDER):
+            shutil.rmtree(OUTPUT_FOLDER)
+
 
     def test_get_width(self):
         """Tests that getting the width of the tree behaves as expected.
@@ -32,25 +42,107 @@ class TestStemmaGenerator(unittest.TestCase):
         np.random.seed(10)
         self.assertEqual(self.stemma.width, 3)
 
+
     def test_generate(self):
         """Tests that generating the stemma behaves as expected.
         """
+        # Test if stemma generation works well.
         print(self.stemma.generate())
+        # Sanity check for the number of manuscripts.
+        width_min = self.stemma.config.stemma.width.min
+        width_max = self.stemma.config.stemma.width.max - 1
+        depth = self.stemma.depth
+        nbr_mss_max = (1 - width_max**(depth + 2)) / (1 - width_max)
+        nbr_mss_min = (1 - width_min**(depth + 2)) / (1 - width_min)
+        self.assertTrue(
+            nbr_mss_min <= len(self.stemma.texts_lookup) <= nbr_mss_max
+        )
+
 
     def test_apply_level(self):
         """Tests that applying on a single level behaves as expected.
         """
+        expected_result = [
+            'Love bade welcome yet oy soul hrew back hangdog of dust bjd sin.',
+            'love bade welcome yet my soulfulness hrew back guilty of dust ajd .', 
+            'love bade welcome yet my soul hbew back guilty of dust ajd sin.'
+        ]
         np.random.seed(10)
         self.assertListEqual(
             self.stemma._apply_level(self.text),
-            ['Love bade welcome yet oy soul hrew back hangdog of dust bjd sin.', 
-             'love bade welcome yet my soulfulness hrew back guilty of dust ajd .', 
-             'love bade welcome yet my soul hbew back guilty of dust ajd sin.']
+            expected_result
         )
+
 
     def test_graph_repr(self):
         """Tests that representation as a graph works as expected.
         """
+
+
+    def test_dict(self):
+        """Tests the dict representation of the stemma.
+        """
+        generated_stemma = self.stemma.generate()
+        stemma_dict = generated_stemma.dict()
+        # Check if the dictionary is a non-empty dict
+        self.assertIsInstance(stemma_dict, dict)
+        self.assertGreater(len(stemma_dict), 0)
+        self.assertIn(self.text, stemma_dict)
+
+    def test_missing_manuscripts(self):
+        """Tests the missing_manuscripts method.
+        """
+        # Generate the stemma
+        generated_stemma = self.stemma.generate()
+
+        # Call the missing_manuscripts method
+        mss_non_missing, edges_non_missing = generated_stemma.missing_manuscripts()
+
+        # Check if the selected missing manuscripts are not present in edge.
+        for mss in generated_stemma.texts_lookup:
+            if mss not in mss_non_missing:
+                for edge in edges_non_missing:
+                    self.assertNotIn(mss, edge)
+
+        # Check if the returned data is of the correct types
+        self.assertIsInstance(mss_non_missing, dict)
+        self.assertIsInstance(edges_non_missing, list)
+
+        # Calculate the expected number of missing manuscripts based on the configured rate
+        total_manuscripts = len(generated_stemma.texts_lookup)
+        configured_rate = generated_stemma.missing_manuscripts_rate
+        expected_missing_count = int(configured_rate * total_manuscripts)
+        # Check if the number of missing manuscripts matches the expected count
+        actual_missing_count = total_manuscripts - len(mss_non_missing)
+        self.assertEqual(actual_missing_count, expected_missing_count)
+
+
+    def test_dump(self):
+        """Tests the dump method and checks the generated folder and files.
+        """
+        # Generate the stemma and dump it
+        generated_stemma = self.stemma.generate()
+        generated_stemma.dump(OUTPUT_FOLDER)
+
+        # Check if the output folder exists
+        self.assertTrue(os.path.exists(OUTPUT_FOLDER))
+        self.assertTrue(os.path.isdir(OUTPUT_FOLDER))
+
+        # Check if all files in the folder have the ".txt" extension
+        for filename in os.listdir(OUTPUT_FOLDER):
+            file_path = os.path.join(OUTPUT_FOLDER, filename)
+            if os.path.isfile(file_path):  # Check if it's a file (not a folder)
+                self.assertTrue(filename.endswith(".txt"))
+
+        # Check that the "edges.txt" file exists in the folder
+        edges_file_path = os.path.join(OUTPUT_FOLDER, "edges.txt")
+        self.assertTrue(os.path.exists(edges_file_path))
+
+        # Check that a subfolder "missing_manuscripts" is created
+        missing_manuscripts_folder = os.path.join(OUTPUT_FOLDER, "missing_tradition")
+        self.assertTrue(os.path.exists(missing_manuscripts_folder))
+        self.assertTrue(os.path.isdir(missing_manuscripts_folder))
+
 
 
 if __name__ == "__main__":

--- a/src/tests/test_generate_tree.py
+++ b/src/tests/test_generate_tree.py
@@ -3,7 +3,8 @@
 
 import unittest
 from pathlib import Path
-import random
+
+import numpy as np
 from stemmabench.config_parser import StemmaBenchConfig
 from stemmabench.stemma_generator import Stemma
 
@@ -28,7 +29,7 @@ class TestStemmaGenerator(unittest.TestCase):
     def test_get_width(self):
         """Tests that getting the width of the tree behaves as expected.
         """
-        random.seed(10)
+        np.random.seed(10)
         self.assertEqual(self.stemma.width, 3)
 
     def test_generate(self):
@@ -39,12 +40,12 @@ class TestStemmaGenerator(unittest.TestCase):
     def test_apply_level(self):
         """Tests that applying on a single level behaves as expected.
         """
-        random.seed(10)
+        np.random.seed(10)
         self.assertListEqual(
             self.stemma._apply_level(self.text),
-            ['love bade  yet my soul hrew hack guilty of dust ajd sjn.',
-             'love bade welcome yet my soul hrew back shamefaced of dust ajd sin.',
-             'love bade oelcome so far my soul hrew back guilty of  ajd sin.']
+            ['Love bade welcome yet oy soul hrew back hangdog of dust bjd sin.', 
+             'love bade welcome yet my soulfulness hrew back guilty of dust ajd .', 
+             'love bade welcome yet my soul hbew back guilty of dust ajd sin.']
         )
 
     def test_graph_repr(self):

--- a/src/tests/test_text_units.py
+++ b/src/tests/test_text_units.py
@@ -1,8 +1,8 @@
 """
 Unit tests for textual units.
 """
-import random
 import unittest
+import numpy as np
 from stemmabench.config_parser import MetaConfig, ProbabilisticConfig, VariantConfig
 from stemmabench.textual_units.text import Text
 from stemmabench.textual_units.sentence import Sentence
@@ -16,7 +16,7 @@ class TestWord(unittest.TestCase):
     def setUp(self):
         """Setup the unit test.
         """
-        random.seed(1)
+        np.random.seed(1)
         self.test_word = Word("rabbit")
         self.test_word_no_synonym = Word("toto")
 
@@ -35,7 +35,7 @@ class TestWord(unittest.TestCase):
     def test_synonym(self):
         """Tests that returning a synonym works as expected when.
         """
-        self.assertEqual(self.test_word.synonym(), "lapin")
+        self.assertEqual(self.test_word.synonym(), "hare")
 
     def test_no_synonym(self):
         """Tests that returning a synonym works as expected when.
@@ -45,7 +45,7 @@ class TestWord(unittest.TestCase):
     def test_mispell(self):
         """Tests that mispells behave as expected.
         """
-        self.assertEqual(self.test_word.mispell(), "rsbbit")
+        self.assertEqual(self.test_word.mispell(), "rabbil")
 
     def test_omit(self):
         """Tests that omitting a word behaves as expected.
@@ -78,7 +78,7 @@ class TestSentence(unittest.TestCase):
     def setUp(self):
         """Set up the unit tests.
         """
-        random.seed(5)
+        np.random.seed(5)
         self.test_sentence = Sentence("The rabbit is blue.")
 
     def test_init_sentence(self):
@@ -112,7 +112,7 @@ class TestText(unittest.TestCase):
         """Setup the unit testing by creating a test instance of the
         text.
         """
-        random.seed(15)
+        np.random.seed(15)
         self.test_text = Text(
             "But, first, remember, remember, remember the signs. "
             "Say them to yourself when you wake in the morning "
@@ -152,7 +152,7 @@ class TestText(unittest.TestCase):
         transformed_sentence = self.test_text.transform_sentence(self.test_text.sentences[0],
                                                                  sentence_config=test_config)
         self.assertEqual(transformed_sentence,
-                         "But but first remember remember remember the signs.")
+                         "But first remember remember remember remember the signs.")
 
     def test_sentences_transform(self):
         """Tests that transformation for all the sentences of the text behaves
@@ -173,8 +173,8 @@ class TestText(unittest.TestCase):
         )
         self.assertEqual(
             transformed_sentences,
-            "But but first remember remember remember the signs. "
-            "Say say them to yourself when you wake in the morning and when you lie "
+            "But first remember remember remember remember the signs. "
+            "Say them to yourself when you wake in the morning and when you lie "
             "down at night and when you wake in the middle of the night."
         )
 
@@ -199,7 +199,7 @@ class TestText(unittest.TestCase):
 
             })
         }
-        self.assertEqual("fwake",
+        self.assertEqual("home alive",
                          self.test_text.transform_word(self.test_text.words[27],
                                                        word_config=word_config))
 
@@ -224,7 +224,7 @@ class TestText(unittest.TestCase):
             })
         }
         self.assertEqual(
-            "bub bue fiost remgmber remembhr remembes thu pigns",
+            "hut onlx firmt  relember reiember hhe figns",
             self.test_text.transform_words(
                 sentence="But but first remember remember remember the signs.",
                 word_config=word_config,
@@ -233,6 +233,7 @@ class TestText(unittest.TestCase):
     def test_text_transform(self):
         """Tests that the transformation of the text behaves as expected.
         """
+        np.random.seed(15)
         meta_config = MetaConfig(**{"language": "en"})
         variant_config = VariantConfig(**{
             "sentences": {
@@ -263,9 +264,9 @@ class TestText(unittest.TestCase):
                 })
             }}
         )
-        self.assertEqual("But bht firit rememzer remembhr remembes thu pigns. Saf jay  tm yoursclf whmn you vake  tfe morbing ahd  yom rert dowa et nihht anl wuen yos wade is dhe muddle ol thd nioht.",
-            self.test_text.transform(variant_config=variant_config, meta_config=meta_config)
-        )
+        result = self.test_text.transform(variant_config=variant_config, meta_config=meta_config)
+        expected_result = "Bwt  remenber rerember  wemember hhe figns. Smy mhem tc yoarself whef yog sake im thb mornini acd yhen  lde doen astatinz  dnd whec nou wawe vn the   tce nigwt."
+        self.assertEqual(expected_result, result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The missing manuscript option allows deleting some manuscripts from the stemma. It requires specifying the proportion of manuscripts to delete in the configuration parser.

* src/stemmabench/config_parser.py
    - Add `missing_manuscripts` field to StemmaConfig.

* src/stemmabench/stemma_generator.py
    - Add a `missing_manuscripts` method in `Stemma` class.
    - Create a missing tradition in output_folder when using CLI.

* demo/config.yaml
* src/tests/test_data/config.yaml
    - Update configuration files to account for missing manuscripts.

* src/stemmabench/textual_units/word.py
    - fixing `mispell`